### PR TITLE
set proper ingress api version

### DIFF
--- a/charts/lenses/Chart.yaml
+++ b/charts/lenses/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: "v1"
 description: A chart for Lenses
 name: lenses
-version: 4.0.20
+version: 4.0.21
 appVersion: 4.0.8
 icon: https://www.lenses.io/images/logos/icon_ellipse2red.png

--- a/charts/lenses/templates/_helper.tpl
+++ b/charts/lenses/templates/_helper.tpl
@@ -464,3 +464,14 @@ lenses.security.saml.key.password={{ .Values.lenses.security.saml.keyPassword | 
 {{ include "kerberos" .}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Return the appropriate apiVersion for ingress.
+*/}}
+{{- define "ingress.apiVersion" -}}
+{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" -}}
+{{- print "networking.k8s.io/v1beta1" -}}
+{{- else -}}
+{{- print "extensions/v1beta1" -}}
+{{- end -}}
+{{- end -}}

--- a/charts/lenses/templates/ingress.yaml
+++ b/charts/lenses/templates/ingress.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.ingress.enabled }}
-apiVersion: extensions/v1beta1
+apiVersion: {{ include "ingress.apiVersion" . }}
 kind: Ingress
 metadata:
   name:  {{ include "fullname" . }}


### PR DESCRIPTION
This PR fixes an issue with the deprecated ingress object in k8s 1.18.
```
Error: malformed chart or values: 
        templates/ingress.yaml: the kind "extensions/v1beta1 Ingress" is deprecated in favor of "networking.k8s.io/v1beta1 Ingress"
```