### PR TITLE
Fix for schemaRegistries.security.authType config

### DIFF
--- a/charts/lenses/templates/_helper.tpl
+++ b/charts/lenses/templates/_helper.tpl
@@ -189,7 +189,8 @@ PLAINTEXT
 
 {{- define "kafkaSchemaBasicAuth" -}}
   {{- if .Values.lenses.schemaRegistries.security.enabled -}}
-    {{- if (.Values.lenses.schemaRegistries.security.authType)  and eq .Values.lenses.schemaRegistries.security.authType "USER_INFO" -}}
+    # Use a default dict to avoid 'can't give argument to non-function'
+    {{- if eq ((.Values.lenses.schemaRegistries.security | default (dict "authType" "")).authType) "USER_INFO" -}}
     {{- .Values.lenses.schemaRegistries.security.username}}:{{.Values.lenses.schemaRegistries.security.password}}
     {{- end -}}
   {{- end -}}


### PR DESCRIPTION
Helm install fails when Schema Registry authentication is enabled and authType is set to USER_INFO. Problem seems to be with the syntax for authType property check.