### PR TITLE
Quoted host so that it can contain a wildcard charater

### DIFF
--- a/charts/lenses/templates/ingress.yaml
+++ b/charts/lenses/templates/ingress.yaml
@@ -27,7 +27,7 @@ spec:
   {{- if .Values.ingress.tls.enabled }}
   tls:
     - hosts:
-      - {{ .Values.ingress.host }}
+      - "{{ .Values.ingress.host }}"
       {{- if .Values.ingress.tls.secretName }}
       secretName: {{ .Values.ingress.tls.secretName }}
       {{- else }}


### PR DESCRIPTION
Without the quote you cannot add a name starting with a wildcard. For example:

ingress.host: "*.now.youcandothis.com"