### PR TITLE
allow different service port name

### DIFF
--- a/charts/lenses/Chart.yaml
+++ b/charts/lenses/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v1
 description: A chart for Lenses
 icon: https://www.lenses.io/images/logos/icon_ellipse2red.png
 name: lenses
-version: 4.3.4
+version: 4.3.5
 appVersion: 4.3.2

--- a/charts/lenses/templates/service.yaml
+++ b/charts/lenses/templates/service.yaml
@@ -25,7 +25,7 @@ spec:
   externalTrafficPolicy: {{ toYaml .Values.service.externalTrafficPolicy }}
   {{- end }}
   ports:
-  - name: lenses
+  - name: {{ .Values.servicePortName }}
     port: {{ .Values.servicePort }}
     {{- if .Values.nodePort }}
     nodePort: {{ .Values.nodePort }}

--- a/charts/lenses/values.yaml
+++ b/charts/lenses/values.yaml
@@ -38,6 +38,7 @@ rbacEnable: true
 # restPort is the Lenses rest port
 restPort: 3030
 servicePort: 80
+servicePortName: lenses
 
 # serviceAccount is the Service account to be used by Lenses to deploy apps
 serviceAccount: default


### PR DESCRIPTION
Customization of the service port name may be needed in few use cases (e.g., the istio service mesh requires the port to be named `http-*`).