### PR TITLE
Fixes error when pulling lenses docker image from private registry

### DIFF
--- a/charts/lenses/Chart.yaml
+++ b/charts/lenses/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v1
 description: A chart for Lenses
 icon: https://www.lenses.io/images/logos/icon_ellipse2red.png
 name: lenses
-version: 4.3.11
+version: 4.3.12
 appVersion: 4.3.4

--- a/charts/lenses/templates/deployment.yaml
+++ b/charts/lenses/templates/deployment.yaml
@@ -40,6 +40,10 @@ spec:
         prometheus.io/port: "9102"
         prometheus.io/path: "/metrics"
     spec:
+      {{- if .Values.image.registrySecretKey }}
+      imagePullSecrets:
+        - name: {{ .Values.image.registrySecretKey }}
+      {{- end }}
       {{- if .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml .Values.nodeSelector | nindent 8 }}
@@ -114,10 +118,6 @@ spec:
       - name: {{ .Chart.Name }}
         image: "{{ .Values.image.repository }}:{{if .Values.image.tag }}{{ .Values.image.tag }}{{else}}{{ .Chart.AppVersion }}{{end}}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
-        {{- if .Values.image.registrySecretKey }}
-        imagePullSecrets:
-        - name: {{ .Values.image.registrySecretKey }}
-        {{- end }}
         ports:
         - containerPort: {{ .Values.restPort }}
         {{- if .Values.lenses.livenessProbe.enabled }}


### PR DESCRIPTION
Fixes issue: https://github.com/lensesio/lenses-helm-charts/issues/11

Re-positioned incorrectly placed `imagePullSecrets` field in `deployment.yaml`