### PR TITLE
Support custom annotations on the deployment pods

### DIFF
--- a/charts/lenses/Chart.yaml
+++ b/charts/lenses/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v1
 description: A chart for Lenses
 icon: https://www.lenses.io/images/logos/icon_ellipse2red.png
 name: lenses
-version: 5.0.1
+version: 5.0.2
 appVersion: 5.0.1

--- a/charts/lenses/templates/deployment.yaml
+++ b/charts/lenses/templates/deployment.yaml
@@ -47,6 +47,9 @@ spec:
         prometheus.io/scrape: "true"
         prometheus.io/port: "9102"
         prometheus.io/path: "/metrics"
+        {{- range $key, $value := .Values.podAnnotations }}
+        {{ $key }}: {{ $value | quote }}
+        {{- end }}
     spec:
       {{- if .Values.nodeSelector }}
       nodeSelector:

--- a/charts/lenses/values.yaml
+++ b/charts/lenses/values.yaml
@@ -10,6 +10,7 @@ image:
   # tag:
 
 annotations: {}
+podAnnotations: {}
 labels: {}
 strategy: {}
 nodeSelector: {}
@@ -28,10 +29,10 @@ monitoring:
 # Resource management
 resources:
   requests:
-  #   cpu: 1
+    #   cpu: 1
     memory: 4Gi
   limits:
-  #   cpu: 2
+    #   cpu: 2
     memory: 5Gi
 
 # rbacEnable indicates if a the cluster has rbac enabled and a cluster role
@@ -123,7 +124,8 @@ ingress:
   # ingressClassName:
 
   # Ingress annotations
-  annotations: {}
+  annotations:
+    {}
     # Optionally add here the annotations related to the ingress provider, see examples below:
     # kubernetes.io/ingress.class: traefik
     # kubernetes.io/ingress.class: nginx
@@ -148,7 +150,8 @@ lenses:
     yaml:
 
     # Find more details in https://docs.lenses.io/current/installation/kubernetes/helm/#helm-provision-secrets
-    secrets: {}
+    secrets:
+      {}
       # Base64 encoded. Read how to convert from .pem to .jks in the article: https://docs.lenses.io/current/configuration/dynamic/pem-to-jks-conversion/
       # data:
       #   kafka.keystore.jks: |-
@@ -170,7 +173,6 @@ lenses:
       additionalVolumeMounts:
         # - name: lenses-super-secrets
         #   mountPath: "/data/lenses-super-secrets"
-
 
   # For additional generic JVM settings
   # Read more: https://docs.lenses.io/current/configuration/static/jvm/
@@ -241,13 +243,12 @@ lenses:
 
     trustStorePassword: |-
 
-
   # Find more details in https://docs.lenses.io/current/installation/kubernetes/helm/#helm-storage
   storage:
     postgres:
       enabled: false
       host:
-      port:               # optional, defaults to 5432
+      port: # optional, defaults to 5432
 
       # Set the username for postgres connection
       # Use the value "external" to bypass the Helm validation and handle the username externally.
@@ -258,7 +259,7 @@ lenses:
       #     secretKeyRef:
       #       name: [SECRET_RESOURCE_NAME]
       #       key: [SECRET_RESOURCE_KEY]
-      username:           # use "external" to manage it using secrets
+      username: # use "external" to manage it using secrets
 
       # Set the password for postgres connection
       # Use the value "external" to bypass the Helm validation and handle the password externally.
@@ -269,10 +270,10 @@ lenses:
       #     secretKeyRef:
       #       name: [SECRET_RESOURCE_NAME]
       #       key: [SECRET_RESOURCE_KEY]
-      password:           # use "external" to manage it using secrets
+      password: # use "external" to manage it using secrets
 
       database:
-      schema:             # optional, defaults to public schema
+      schema: # optional, defaults to public schema
 
   # Data Application Deployment Framework
   # TODO: Link missing for DAD docs
@@ -317,18 +318,17 @@ lenses:
       #       generator-url="http://lenses_prod:port1"
       #     }
 
-
-
   # The url to the grafana host
   grafanaUrl:
 
   # topics
   topics:
-      # suffix to add to lenses system topics, for example if you are running more than one Lenses on the same kafka cluster
+    # suffix to add to lenses system topics, for example if you are running more than one Lenses on the same kafka cluster
     suffix:
 
   security:
-    defaultUser: {}
+    defaultUser:
+      {}
       # Change Default Lenses user credentials.
       # Username: admin / Password:admin
 
@@ -441,7 +441,8 @@ lenses:
   # extra configurations that will be append to the lenses.conf file mounted in /mnt/settings
   ## keys must be uppercase and underscores for separators suit for use as environment variables
   ## see https://docs.lenses.io/install_setup/configuration/lenses-config.html#option-reference
-  configOverrides: {}
+  configOverrides:
+    {}
     #LENSES_PROPERTY : value
 
   # Disable livenessProbe, used while debugging

--- a/charts/lenses/values.yaml
+++ b/charts/lenses/values.yaml
@@ -29,10 +29,10 @@ monitoring:
 # Resource management
 resources:
   requests:
-    #   cpu: 1
+  #   cpu: 1
     memory: 4Gi
   limits:
-    #   cpu: 2
+  #   cpu: 2
     memory: 5Gi
 
 # rbacEnable indicates if a the cluster has rbac enabled and a cluster role
@@ -124,8 +124,7 @@ ingress:
   # ingressClassName:
 
   # Ingress annotations
-  annotations:
-    {}
+  annotations: {}
     # Optionally add here the annotations related to the ingress provider, see examples below:
     # kubernetes.io/ingress.class: traefik
     # kubernetes.io/ingress.class: nginx
@@ -150,8 +149,7 @@ lenses:
     yaml:
 
     # Find more details in https://docs.lenses.io/current/installation/kubernetes/helm/#helm-provision-secrets
-    secrets:
-      {}
+    secrets: {}
       # Base64 encoded. Read how to convert from .pem to .jks in the article: https://docs.lenses.io/current/configuration/dynamic/pem-to-jks-conversion/
       # data:
       #   kafka.keystore.jks: |-
@@ -173,6 +171,7 @@ lenses:
       additionalVolumeMounts:
         # - name: lenses-super-secrets
         #   mountPath: "/data/lenses-super-secrets"
+
 
   # For additional generic JVM settings
   # Read more: https://docs.lenses.io/current/configuration/static/jvm/
@@ -243,12 +242,13 @@ lenses:
 
     trustStorePassword: |-
 
+
   # Find more details in https://docs.lenses.io/current/installation/kubernetes/helm/#helm-storage
   storage:
     postgres:
       enabled: false
       host:
-      port: # optional, defaults to 5432
+      port:               # optional, defaults to 5432
 
       # Set the username for postgres connection
       # Use the value "external" to bypass the Helm validation and handle the username externally.
@@ -259,7 +259,7 @@ lenses:
       #     secretKeyRef:
       #       name: [SECRET_RESOURCE_NAME]
       #       key: [SECRET_RESOURCE_KEY]
-      username: # use "external" to manage it using secrets
+      username:           # use "external" to manage it using secrets
 
       # Set the password for postgres connection
       # Use the value "external" to bypass the Helm validation and handle the password externally.
@@ -270,10 +270,10 @@ lenses:
       #     secretKeyRef:
       #       name: [SECRET_RESOURCE_NAME]
       #       key: [SECRET_RESOURCE_KEY]
-      password: # use "external" to manage it using secrets
+      password:           # use "external" to manage it using secrets
 
       database:
-      schema: # optional, defaults to public schema
+      schema:             # optional, defaults to public schema
 
   # Data Application Deployment Framework
   # TODO: Link missing for DAD docs
@@ -318,17 +318,18 @@ lenses:
       #       generator-url="http://lenses_prod:port1"
       #     }
 
+
+
   # The url to the grafana host
   grafanaUrl:
 
   # topics
   topics:
-    # suffix to add to lenses system topics, for example if you are running more than one Lenses on the same kafka cluster
+      # suffix to add to lenses system topics, for example if you are running more than one Lenses on the same kafka cluster
     suffix:
 
   security:
-    defaultUser:
-      {}
+    defaultUser: {}
       # Change Default Lenses user credentials.
       # Username: admin / Password:admin
 
@@ -441,8 +442,7 @@ lenses:
   # extra configurations that will be append to the lenses.conf file mounted in /mnt/settings
   ## keys must be uppercase and underscores for separators suit for use as environment variables
   ## see https://docs.lenses.io/install_setup/configuration/lenses-config.html#option-reference
-  configOverrides:
-    {}
+  configOverrides: {}
     #LENSES_PROPERTY : value
 
   # Disable livenessProbe, used while debugging


### PR DESCRIPTION
Our service mesh admission controller requires annotations on the pod for sidecar injection. the current implementation only supporting tagging the deployment resource.