### PR TITLE
Add support to group plugin configuration on SAML authentication

### DIFF
--- a/charts/lenses/Chart.yaml
+++ b/charts/lenses/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v1
 description: A chart for Lenses
 icon: https://www.lenses.io/images/logos/icon_ellipse2red.png
 name: lenses
-version: 5.0.1
-appVersion: 5.0.1
+version: 5.0.2
+appVersion: 5.0.2

--- a/charts/lenses/templates/_helper.tpl
+++ b/charts/lenses/templates/_helper.tpl
@@ -228,8 +228,12 @@ lenses.security.ldap.plugin.person.name.key={{ .Values.lenses.security.ldap.plug
 lenses.security.saml.base.url={{ .Values.lenses.security.saml.baseUrl | quote }}
 lenses.security.saml.idp.provider={{ .Values.lenses.security.saml.provider | quote }}
 lenses.security.saml.idp.metadata.file="/mnt/secrets/saml.idp.xml"
+lenses.security.saml.idp.session.lifetime.max = {{ .Values.lenses.security.saml.idp.session.lifetime.max | quote }}
 lenses.security.saml.keystore.location="/mnt/secrets/saml.keystore.jks"
 lenses.security.saml.keystore.password={{ .Values.lenses.security.saml.keyStorePassword | quote }}
+{{- if .Values.lenses.security.groups.enabled }}
+lenses.security.saml.groups.plugin.class={{ .Values.lenses.security.groups.plugin.class | quote }}
+{{- end -}}
 {{- if .Values.lenses.security.saml.keyAlias }}
 lenses.security.saml.key.alias={{ .Values.lenses.security.saml.keyAlias | quote }}
 {{- end }}

--- a/charts/lenses/values.yaml
+++ b/charts/lenses/values.yaml
@@ -423,6 +423,18 @@ lenses:
       # Password for accessing the private key within the keystore.
       keyPassword:
 
+      # idp settings
+      idp:
+        session:
+          lifetime:
+            max: 100days
+
+     # groups settings
+    groups:
+      enabled: false
+      plugin:
+        class: ""
+
     append:
       conf: |-
 


### PR DESCRIPTION
We use a plugin in the Lenses authentication process to match SAML credentials with lenses group definitions.
The default configuration doesn't allow setting this plugin correctly as the configuration entry is not set in the security.conf file of the container.

With these changes, you can enable groups and define the plugin used.

Also, the property to define session max lifetime can be configured.

Hope it helps!