### PR TITLE
feat(): add security context on the container level

### DIFF
--- a/charts/lenses/templates/deployment.yaml
+++ b/charts/lenses/templates/deployment.yaml
@@ -117,6 +117,8 @@ spec:
         imagePullSecrets:
         - name: {{ .Values.image.registrySecretKey }}
         {{- end }}
+        securityContext:
+          {{- toYaml .Values.containerSecurityContext | nindent 12 }}
         ports:
         - containerPort: {{ .Values.restPort }}
         {{- if .Values.lenses.livenessProbe.enabled }}

--- a/charts/lenses/tests/with-container-security-context.run_test.yaml
+++ b/charts/lenses/tests/with-container-security-context.run_test.yaml
@@ -1,0 +1,16 @@
+suite: add securityContext and verify that container is honoring them
+templates:
+  - deployment.yaml
+tests:
+  - it: should not contain containerSecurityContext with default values
+    asserts:
+      - isEmpty:
+          path: spec.template.spec.containers[0].securityContext
+  - it: should honor containerSecurityContext
+    set:
+      containerSecurityContext:
+        allowPrivilegeEscalation: false
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.allowPrivilegeEscalation
+          value: false

--- a/charts/lenses/values.yaml
+++ b/charts/lenses/values.yaml
@@ -16,6 +16,7 @@ nodeSelector: {}
 tolerations: {}
 affinity: {}
 securityContext: {}
+containerSecurityContext: {}
 
 # Add Prometheus annotations to the pod for Lenses metric scraping
 monitoring:


### PR DESCRIPTION
It is recommended practice to give a resource (pod/container) the least privileges it needs. The Lenses Helm Chart already supports configuring the security context on the pod level. This PR adds the `securityContext` configurations on the container level ([more info on container level securityContext here](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container)).

This change is fully backwards compatible, as the `containerSecurityContext` value configuration is optional and defaults to `{}`